### PR TITLE
Bring back original ctx namespace

### DIFF
--- a/apps/wapi/src/wapi_backend_utils.erl
+++ b/apps/wapi/src/wapi_backend_utils.erl
@@ -8,7 +8,7 @@
 -include_lib("fistful_proto/include/ff_proto_withdrawal_thrift.hrl").
 
 -define(EXTERNAL_ID, <<"externalID">>).
--define(CTX_NS, <<"dev.vality.wapi">>).
+-define(CTX_NS, <<"com.rbkmoney.wapi">>).
 -define(BENDER_DOMAIN, <<"wapi">>).
 
 %% Context


### PR DESCRIPTION
Since it breaks reads of existing objects.